### PR TITLE
Add a note about install_all.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ When developing from within the mono-repo, the libraries can be individually ins
 
 To install the base dependencies, run `pip install -e .` from the mono-repo root. Development dependencies can be installed with `pip install -e .[dev-dependencies]`
 
-To install the library dependencies, run, for example, `pip install -e src/web` to install `BL_Python.web`. Similar to the mono-repo, development dependencies can be installed with `pip install -e src/web[dev-dependencies]`.
+To install the library dependencies, run, for example, `pip install -e src/web` to install `BL_Python.web`. Similar to the mono-repo, development dependencies can be installed with `pip install -e src/web[dev-dependencies]`. To install all libraries, you can run `./install_all.sh`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of Python libraries for creating web applications, working with dat
 
 # Using `BL_Python` in your projects
 
-Currently these libraries are not available in any package repository, and so much be imported via other means.
+Currently these libraries are not available in any package repository, and so must be imported via other means.
 
 The suggested method is to use the `git+ssh` [VCS URL](https://pip.pypa.io/en/stable/topics/vcs-support/) with `pip`.
 


### PR DESCRIPTION
In the README under "Development" I have added a note that you can run `./install_all.sh` to install all libraries in the monorepo.