### PR TITLE
Rename root package to `.all` and add dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 
 [project]
-name = "BL_Python"
+name = "BL_Python.all"
 requires-python = ">=3.10"
 authors = [
     {name = 'Aaron Holmes', email = 'aholmes@mednet.ucla.edu'}
@@ -27,7 +27,15 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Natural Language :: English"
 ]
-dependencies = []
+dependencies = [
+    "BL_Python.AWS",
+    "BL_Python.database",
+    "BL_Python.development",
+    "BL_Python.platform",
+    "BL_Python.programming",
+    "BL_Python.testing",
+    "BL_Python.web"
+]
 
 dynamic = ["version", "readme"]
 [tool.setuptools.dynamic]


### PR DESCRIPTION
The root package cannot be named `BL_Python` because PyPI deems it "too similar" to some other unknown package.
As a compromise, the package name will now be `BL_Python.all`, but the content is still under the `BL_Python` namespace.

In addition, because the root package should install everything, I have added the other packages as dependencies.