### PR TITLE
Move exposure of github token from job to steps.

### DIFF
--- a/.github/workflows/PyPI.yaml
+++ b/.github/workflows/PyPI.yaml
@@ -75,9 +75,6 @@ jobs:
       contents: write
       id-token: write
 
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
-
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v3
@@ -91,6 +88,8 @@ jobs:
             ./dist/*.tar.gz
             ./dist/*.whl
       - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         # TODO change the release notes to use the changelog
         run: >-
           gh release create
@@ -98,6 +97,8 @@ jobs:
           --repo '${{ github.repository }}'
           --notes ""
       - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           gh release upload
           '${{ github.ref_name }}' dist/**


### PR DESCRIPTION
Related: https://github.com/pypa/packaging.python.org/pull/1323
