### PR TITLE
Use test short names in .cicd-env

### DIFF
--- a/.cicd-env
+++ b/.cicd-env
@@ -1,2 +1,2 @@
-IGNORE_NAMED_TESTS="bllinter.test_all.CommonTestCase.test_repo_name:bllinter.test_all.LinterTestCase.test_python_linting"
+IGNORE_NAMED_TESTS="repo-name:python-linting"
 PYTHON_PYLINT_CONFIG_FILE=true


### PR DESCRIPTION
This incorporates the changes from https://github.com/uclahs-cds/docker-CICD-base/pull/77 to simplify the ignored test names in the `.cicd-env` file.

The main advantage of this is that it decouples the external interface from the internal test implementation, so we can reorganize the CICD-test repo without requiring more changes to this repository.