### PR TITLE
Replace black with ruff

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -223,7 +223,7 @@ jobs:
       - name: Check code style
         run: |
           source .github-venv/bin/activate
-          black --check src
+          ruff format --preview --respect-gitignore --check
 
       - name: Check import order
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dev-dependencies = [
     # which allows us to catch new types of problems.
     "pyright",
     "isort",
-    "black"
+    "ruff == 0.2.2"
 ]
 
 [tool.pyright]
@@ -214,8 +214,29 @@ omit = [
 ]
 branch = true
 
-[tool.black]
-exclude = "src/.+/(typings|build)"
+[tool.ruff]
+include = [
+    "pyproject.toml",
+    "src/**/*.py",
+    "src/**/*.pyi",
+    "test/**/*.py",
+    "test/**.*.pyi",
+]
+[tool.ruff.format]
+exclude = [
+    "typings/**/*.py",
+    "typings/**/*.pyi",
+    "src/**/typings/**/*.py",
+    "src/**/typings/**/*.pyi",
+    "src/**/build/**/*.py",
+    "src/**/build/**/*.pyi",
+]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = false
+docstring-code-line-length = "dynamic"
 
 [tool.isort]
 profile = "black"

--- a/src/GitHub/BL_Python/GitHub/api.py
+++ b/src/GitHub/BL_Python/GitHub/api.py
@@ -71,9 +71,7 @@ class GitHub:
         repository = self._client.get_repo(f"{organization_name}/{repository_name}")
         organization: Organization = self._client.get_organization(organization_name)
         # fixes the PyGithub API URLs for working with the organiztion owning the repository
-        cast(
-            Any, repository._organization  # pyright: ignore[reportPrivateUsage]
-        )._value = organization
+        cast(Any, repository._organization)._value = organization  # pyright: ignore[reportPrivateUsage]
         return repository
 
     def create_repository(

--- a/src/programming/BL_Python/programming/patterns/singleton.py
+++ b/src/programming/BL_Python/programming/patterns/singleton.py
@@ -2,7 +2,7 @@
 # pylint: disable=E1003
 # pylint: disable=W0613
 # pylint: disable=C0204
-""" Module containg Singleton metaclass """
+"""Module containg Singleton metaclass"""
 
 # pyright: reportPrivateUsage=false
 

--- a/src/web/BL_Python/web/config.py
+++ b/src/web/BL_Python/web/config.py
@@ -59,15 +59,13 @@ class FlaskSessionCookieConfig(BaseModel):
         if not self.secret_key:
             raise Exception("`flask.session.cookie.secret_key` must be set in config.")
 
-        environ.update(
-            {
-                "SECRET_KEY": self.secret_key,
-                "SESSION_COOKIE_NAME": self.name,
-                "SESSION_COOKIE_HTTPONLY": str(1 if self.httponly else 0),
-                "SESSION_COOKIE_SECURE": str(1 if self.secure else 0),
-                "SESSION_COOKIE_SAMESITE": self.samesite,
-            }
-        )
+        environ.update({
+            "SECRET_KEY": self.secret_key,
+            "SESSION_COOKIE_NAME": self.name,
+            "SESSION_COOKIE_HTTPONLY": str(1 if self.httponly else 0),
+            "SESSION_COOKIE_SECURE": str(1 if self.secure else 0),
+            "SESSION_COOKIE_SAMESITE": self.samesite,
+        })
 
     def _update_flask_config(self, flask_app_config: FlaskAppConfig):
         class ConfigObject:
@@ -87,17 +85,11 @@ class FlaskSessionConfig(BaseModel):
     refresh_each_request: bool = True
 
     def _prepare_env_for_flask(self):
-        environ.update(
-            {
-                "PERMANENT_SESSION": str(1 if self.permanent else 0),
-                "PERMANENT_SESSION_LIFETIME": (
-                    str(self.lifetime) if self.lifetime else ""
-                ),
-                "SESSION_REFRESH_EACH_REQUEST": str(
-                    1 if self.refresh_each_request else 0
-                ),
-            }
-        )
+        environ.update({
+            "PERMANENT_SESSION": str(1 if self.permanent else 0),
+            "PERMANENT_SESSION_LIFETIME": (str(self.lifetime) if self.lifetime else ""),
+            "SESSION_REFRESH_EACH_REQUEST": str(1 if self.refresh_each_request else 0),
+        })
         self.cookie._prepare_env_for_flask()  # pyright: ignore[reportPrivateUsage]
 
     def _update_flask_config(self, flask_app_config: FlaskAppConfig):

--- a/src/web/BL_Python/web/middleware/dependency_injection.py
+++ b/src/web/BL_Python/web/middleware/dependency_injection.py
@@ -26,9 +26,7 @@ class AppModule(Module):
         super().__init__()
         if isinstance(app, Flask):
             self._flask_app = app
-        elif isinstance(
-            app, FlaskApp
-        ):  # pyright: ignore[reportUnnecessaryIsInstance] guard against things like not using `MagicMock(spec=...)`
+        elif isinstance(app, FlaskApp):  # pyright: ignore[reportUnnecessaryIsInstance] guard against things like not using `MagicMock(spec=...)`
             self._flask_app = app.app
         else:
             raise ValueError(

--- a/src/web/BL_Python/web/middleware/openapi/__init__.py
+++ b/src/web/BL_Python/web/middleware/openapi/__init__.py
@@ -166,9 +166,7 @@ def _headers_as_dict(
     request_response: MiddlewareRequestDict | MiddlewareResponseDict,
 ):
     if (
-        isinstance(
-            request_response, dict
-        )  # pyright: ignore[reportUnnecessaryIsInstance]
+        isinstance(request_response, dict)  # pyright: ignore[reportUnnecessaryIsInstance]
         and "headers" in request_response.keys()
     ):
         # FIXME does this work for a middleware _response_ as well?
@@ -430,16 +428,18 @@ class CorrelationIDMiddleware:
                     _ = uuid.UUID(request_correlation_id.decode(encoding))
                 else:
                     request_correlation_id = str(uuid4()).encode(encoding)
-                    request_headers.append(
-                        (correlation_id_header_encoded, request_correlation_id)
-                    )
+                    request_headers.append((
+                        correlation_id_header_encoded,
+                        request_correlation_id,
+                    ))
                     log.info(
                         f'Generated new UUID "{request_correlation_id}" for {CORRELATION_ID_HEADER} request header.'
                     )
 
-                response_headers.append(
-                    (correlation_id_header_encoded, request_correlation_id)
-                )
+                response_headers.append((
+                    correlation_id_header_encoded,
+                    request_correlation_id,
+                ))
 
                 return await send(message)
             except ValueError as e:

--- a/src/web/BL_Python/web/scaffolding/__main__.py
+++ b/src/web/BL_Python/web/scaffolding/__main__.py
@@ -23,9 +23,7 @@ APPLICATION_ENDPOINT_PATH_NAME = "application"
 
 
 class ScaffoldInputArgs(Namespace):
-    mode: Literal[  # pyright: ignore[reportUninitializedInstanceVariable]
-        "create", "modify"
-    ]
+    mode: Literal["create", "modify"]  # pyright: ignore[reportUninitializedInstanceVariable]
     mode_executor: "Callable[[ScaffoldParsedArgs], None]"  # pyright: ignore[reportUninitializedInstanceVariable]
     name: Operation  # pyright: ignore[reportUninitializedInstanceVariable]
     endpoints: list[Operation] | None = None

--- a/src/web/BL_Python/web/scaffolding/scaffolder.py
+++ b/src/web/BL_Python/web/scaffolding/scaffolder.py
@@ -42,7 +42,6 @@ class Operation:
 
     @override
     def __eq__(self, __value: object) -> bool:
-
         return isinstance(__value, Operation) and (
             self.url_path_name == __value.url_path_name
             or self.module_name == __value.module_name

--- a/src/web/test/unit/create_app.py
+++ b/src/web/test/unit/create_app.py
@@ -256,9 +256,7 @@ class CreateApp:
         with ExitStack() as stack:
             result = flask_app_getter()
 
-            if not isinstance(
-                result, AppInjector
-            ) or not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            if not isinstance(result, AppInjector) or not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
                 result.app, Flask
             ):
                 raise Exception(
@@ -284,7 +282,9 @@ Ensure either that [openapi] is not set in the [flask] config, or use the `opena
                 ),
                 domain="localhost",
                 # fmt: off
-                max_age=app.config['PERMANENT_SESSION_LIFETIME'] if app.config['PERMANENT_SESSION'] else None,
+                max_age=app.config["PERMANENT_SESSION_LIFETIME"]
+                if app.config["PERMANENT_SESSION"]
+                else None,
                 # fmt: on
             )
 
@@ -296,9 +296,7 @@ Ensure either that [openapi] is not set in the [flask] config, or use the `opena
         with ExitStack() as stack:
             result = flask_app_getter()
 
-            if not isinstance(
-                result, AppInjector
-            ) or not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
+            if not isinstance(result, AppInjector) or not isinstance(  # pyright: ignore[reportUnnecessaryIsInstance]
                 result.app, FlaskApp
             ):
                 raise Exception(

--- a/src/web/test/unit/scaffolding/test_scaffolding.py
+++ b/src/web/test/unit/scaffolding/test_scaffolding.py
@@ -188,10 +188,9 @@ def test__parse_args__disallows_duplicated_endpoint_names(
     with pytest.raises(SystemExit) as e:
         # foo-bar and foo_bar are normalized and are equivalent.
         # no need to duplicate the name normalization tests; just use the exact values here
-        _ = ScaffolderCli()._parse_args(
-            [mode, "-n", "test", "-e", "foo", "-e", "foo_bar", "-e", "foo-bar"]
-        )
-        # T
+        # fmt: off
+        _ = ScaffolderCli()._parse_args([mode, "-n", "test", "-e", "foo", "-e", "foo_bar", "-e", "foo-bar"])
+        # fmt: on
     captured = capsys.readouterr()
     assert e.value.code == 2
     assert (


### PR DESCRIPTION
This change:

- Replaces `black` with `ruff==0.2.2` in `/pyproject.toml`
- Defines inclusion/exclusion rules for `ruff`
- Includes default values for formatting
- Updates CICD to use `ruff`
- Specifies to use `ruff`'s `--preview` mode
- Reformats some files to account for the differences between `black` and `ruff`