### PR TITLE
Add a Makefile

### DIFF
--- a/.github/workflows/CICD-scripts/pyproject_dependency_rewrite.py
+++ b/.github/workflows/CICD-scripts/pyproject_dependency_rewrite.py
@@ -51,7 +51,6 @@ _ = parser.add_argument(
     "--config",
     type=Path,
     action=BL_Python_argparse.PathExists,
-    # action="append",
     help="The path to the pyproject.toml file to rewrite. If not specified, all pyproject.toml under src/*/pyproject.toml, and pyproject.toml will be processed.",
     required=False,
 )

--- a/.github/workflows/CICD-scripts/pyproject_dependency_rewrite.py
+++ b/.github/workflows/CICD-scripts/pyproject_dependency_rewrite.py
@@ -24,7 +24,7 @@ module_path = Path(
 )
 spec = importlib.util.spec_from_file_location(programming_module_name, str(module_path))
 if spec is None or not spec.loader:
-    raise Exception(f"Could not module `{programming_module_name}`.")
+    raise Exception(f"Could not find module `{programming_module_name}`.")
 BL_Python_argparse = importlib.util.module_from_spec(spec)
 sys.modules[programming_module_name] = BL_Python_argparse
 spec.loader.exec_module(BL_Python_argparse)

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -83,16 +83,12 @@ jobs:
         #if: ${{ success() && (inputs.use_dependency_cache == 'false' || !steps.restore-dependency-cache.outputs.cache-hit) }}
         run: |
           echo Setting up dependencies
-          python -m pip install -U pip
-          python -m pip install toml
+          VENV=.github-venv \
           REWRITE_DEPENDENCIES=${{ inputs.rewrite_dependencies }} \
-            ./.github/workflows/CICD-scripts/pyproject_dependency_rewrite.py
-          ${{ steps.install_python.outputs.python-path }} -m venv .github-venv
-          source .github-venv/bin/activate
+            make cicd
 
           echo 'prefix=${{ github.workspace }}/node_modules' >> ~/.npmrc
           npm install -g pyright@`pyright --version | awk '{print $2}'`
-          ./install_all.sh cicd
 
       # TODO see note above about 3rd party dependencies.
       #- name: Save dependency cache
@@ -141,8 +137,10 @@ jobs:
       - name: Test with pyright
         run: |
           echo Running pyright
-          source ${{ github.workspace }}/.github-venv/bin/activate
-          ./node_modules/bin/pyright
+
+          VENV=.github-venv \
+          PYRIGHT_MODE=npm \
+            make test-pyright
 
   Pytest:
     name: Automated testing
@@ -173,10 +171,10 @@ jobs:
       - name: Test with pytest and generate reports
         run: |
           echo Running pytest
-          source ${{ github.workspace }}/.github-venv/bin/activate
-          pytest -k "not acceptance"
 
-          coverage html
+          VENV=.github-venv \
+          PYTEST_FLAGS="-k 'not acceptance'" \
+            make test-pytest
 
       - name: Output pytest report
         uses: actions/upload-artifact@v4
@@ -187,7 +185,7 @@ jobs:
             pytest.xml
             cov.xml
             .coverage
-            htmlcov/
+            coverage/
           retention-days: 1
           if-no-files-found: error
 
@@ -219,13 +217,13 @@ jobs:
 
       - name: Check code style
         run: |
-          source .github-venv/bin/activate
-          ruff format --preview --respect-gitignore --check
+          VENV=.github-venv \
+            make test-ruff
 
       - name: Check import order
         run: |
-          source .github-venv/bin/activate
-          isort --check-only src
+          VENV=.github-venv \
+            make test-isort
 
   Final-status-check:
     name: Check workflow success

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -91,11 +91,8 @@ jobs:
           source .github-venv/bin/activate
 
           echo 'prefix=${{ github.workspace }}/node_modules' >> ~/.npmrc
-          # Note that currently pyproject.toml does not specify a version.
-          # As such, this will install the latest Pyright, including
-          # potentionally breaking changes.
-          npm install -g pyright
-          ./install_all.sh -e
+          npm install -g pyright@`pyright --version | awk '{print $2}'`
+          ./install_all.sh cicd
 
       # TODO see note above about 3rd party dependencies.
       #- name: Save dependency cache

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ ifeq ($(GITHUB_WORKSPACE),)
   GITHUB_WORKSPACE := $(CURDIR)
 endif
 
+# Can be overridden. Use "pypi" to publish to production.
+ifeq ($(PYPI_REPO),)
+  PYPI_REPO := testpypi
+endif
+
 
 ACTIVATE_VENV := . $(VENV)/bin/activate
 
@@ -129,6 +134,11 @@ test-pytest :
 
 test : CMD_PREFIX=@
 test : clean-test test-isort test-ruff test-pyright test-pytest
+
+publish-all :
+	$(ACTIVATE_VENV)
+
+	./publish_all.sh $(PYPI_REPO)
 
 clean-build :
 	find . -type d \( \

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ dev : venv filesystem-deps latest-pip
 #	but it should be for development
 	pip install -e src/database[postgres-binary]
 
-#	rm -rf $(PACKAGE_INSTALL_DIR)
+	rm -rf $(PACKAGE_INSTALL_DIR)
 	@echo '\nActivate your venv with `. $(VENV)/bin/activate`'
 
 cicd : venv filesystem-deps latest-pip

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ endif
 
 
 ACTIVATE_VENV := . $(VENV)/bin/activate
+REPORT_VENV_USAGE := echo '\nActivate your venv with `. $(VENV)/bin/activate`'
 
 PACKAGE_INSTALL_DIR := $(VENV)/lib/python*/site-packages/BL_Python
 
@@ -65,8 +66,6 @@ endef
 PYPROJECT_FILES=./pyproject.toml $(wildcard src/*/pyproject.toml)
 PACKAGE_PATHS=$(subst /pyproject.toml,,$(PYPROJECT_FILES))
 PACKAGES=BL_Python.all $(subst /pyproject.toml,,$(subst src/,BL_Python.,$(wildcard src/*/pyproject.toml)))
-
-REPORT_VENV_USAGE := echo '\nActivate your venv with `. $(VENV)/bin/activate`'
 
 # Rather than duplicating BL_Python.all,
 # just prereq it.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ DEFAULT_TARGET ?= dev
 .DEFAULT_GOAL = $(DEFAULT_TARGET)
 
 define assign_default_target
-	DEFAULT_TARGET := $(1)
+    DEFAULT_TARGET := $(1)
 endef
 
 ifeq ($(DEFAULT_TARGET),dev)
@@ -236,7 +236,7 @@ remake :
 	make
 
 reset-check:
-#   https://stackoverflow.com/a/47839479
+#	https://stackoverflow.com/a/47839479
 	@echo -n "This will make destructive changes! Considering stashing changes first.\n"
 	@( read -p "Are you sure? [y/N]: " response && case "$$response" in [yY]) true;; *) false;; esac )
 

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,45 @@
 .ONESHELL:
 
 # Can be overridden to use a different directory name.
-ifeq ($(VENV),)
-  VENV := .venv
-endif
+VENV ?= .venv
 
 # Can be overridden to use a different Python version.
-ifeq ($(PYTHON_VERSION),)
-  PYTHON_VERSION := 3.10
-endif
+PYTHON_VERSION ?= 3.10
 
 # Can be overridden to pass flags to pytest, like `-k`.
-ifeq ($(PYTEST_FLAGS),)
-  PYTEST_FLAGS :=
-endif
+PYTEST_FLAGS ?=
 
 # Can be overridden to change what pyright command is run.
 # This is used to switch between the pip and npm commands.
-ifeq ($(PYRIGHT_MODE),)
-  PYRIGHT_MODE := pip
-endif
+PYRIGHT_MODE ?= pip
 
 # Can be overridden to change whether packages in the repo
 # will be installed from PyPI or the local filesystem.
-ifeq ($(REWRITE_DEPENDENCIES),)
-  REWRITE_DEPENDENCIES := true
-endif
+REWRITE_DEPENDENCIES ?= true
 
 # Can be overridden.
-ifeq ($(GITHUB_REF),)
-  GITHUB_REF := 00000000-0000-0000-0000-000000000000
-endif
+GITHUB_REF ?= 00000000-0000-0000-0000-000000000000
 
 # Can be overridden.
-ifeq ($(GITHUB_WORKSPACE),)
-  GITHUB_WORKSPACE := $(CURDIR)
-endif
+GITHUB_WORKSPACE ?= $(CURDIR)
 
-# Can be overridden. Use "pypi" to publish to production.
-ifeq ($(PYPI_REPO),)
-  PYPI_REPO := testpypi
+PYPI_REPO ?= testpypi
+
+# Can be overridden. This is used to change the prereqs
+# of some supporting targets, like `format-ruff`.
+# This variable is reassigned to whichever of the dev/cicd
+# targets actually runs.
+DEFAULT_TARGET ?= dev
+.DEFAULT_GOAL = $(DEFAULT_TARGET)
+
+define assign_default_target
+	DEFAULT_TARGET := $(1)
+endef
+
+ifeq ($(DEFAULT_TARGET),dev)
+else ifeq ($(DEFAULT_TARGET),cicd)
+else
+    $(error DEFAULT_TARGET must be one of "dev" or "cicd")
 endif
 
 
@@ -50,69 +50,136 @@ PACKAGE_INSTALL_DIR := $(VENV)/lib/python*/site-packages/BL_Python
 # used to suppress outputs of targets (see `test` and `clean-test`)
 CMD_PREFIX=
 
+define package_to_dist
+$(VENV)/lib/python$(PYTHON_VERSION)/site-packages/BL_Python.$(1)-*.dist-info
+endef
 
-dev : venv filesystem-deps latest-pip
+define package_to_inst
+$(VENV)/lib/python$(PYTHON_VERSION)/site-packages/BL_Python/$(1)/__init__.py
+endef
+
+define dep_to_venv_path
+$(VENV)/lib/python$(PYTHON_VERSION)/site-packages/$(1)
+endef
+
+PYPROJECT_FILES=./pyproject.toml $(wildcard src/*/pyproject.toml)
+PACKAGE_PATHS=$(subst /pyproject.toml,,$(PYPROJECT_FILES))
+PACKAGES=BL_Python.all $(subst /pyproject.toml,,$(subst src/,BL_Python.,$(wildcard src/*/pyproject.toml)))
+
+REPORT_VENV_USAGE := echo '\nActivate your venv with `. $(VENV)/bin/activate`'
+
+# Rather than duplicating BL_Python.all,
+# just prereq it.
+dev : dev_mode BL_Python.all
+
+cicd : cicd_mode $(VENV) $(PYPROJECT_FILES)
+	@if [ -f $(call package_to_inst,) ]; then
+		echo "Package is already built, skipping..."
+	else
+		$(ACTIVATE_VENV)
+
+		pip install .[dev-dependencies]
+#		By default, psycopg2 is not installed
+#		but it should be for CI/CD
+		pip install src/database[postgres-binary]
+	fi
+
+	@$(REPORT_VENV_USAGE)
+
+MODES=dev_mode cicd_mode
+# Used to force DEFAULT_TARGET to whatever
+# the actual .DEFAULT_GOAL is.
+$(MODES):
+	@echo $(call assign_default_target,$(subst _mode,,$@))
+
+
+# BL_Python.all does not have a src/%/pyproject.toml
+# prereq because its pyproject.toml is at /
+BL_Python.all: $(VENV) $(PYPROJECT_FILES)
+	@if [ -d $(call package_to_dist,all) ]; then
+		echo "Package $@ is already built, skipping..."
+	else
+		$(ACTIVATE_VENV)
+
+		pip install -e .[dev-dependencies]
+#		By default, psycopg2 is not installed
+#		but it should be for development
+		pip install -e src/database[postgres-binary]
+
+		rm -rf $(PACKAGE_INSTALL_DIR)
+	fi
+
+	@$(REPORT_VENV_USAGE)
+
+$(filter-out BL_Python.all, $(PACKAGES)): BL_Python.%: src/%/pyproject.toml $(VENV)
+	@if [ -d $(call package_to_dist,$*) ]; then
+		@echo "Package $@ is already built, skipping..."
+	else
+		$(ACTIVATE_VENV)
+
+		if [ "$@" = "BL_Python.database" ]; then
+			pip install -e $(dir $<)[postgres-binary]
+		else
+			pip install -e $(dir $<)
+		fi
+
+		rm -rf $(PACKAGE_INSTALL_DIR)
+	fi
+
+	@$(REPORT_VENV_USAGE)
+
+
+SETUP_DEPENDENCIES=$(call dep_to_venv_path,toml/__init__.py) $(call dep_to_venv_path,typing_extensions.py)
+ $(call dep_to_venv_path,toml/__init__.py): $(VENV)
 	$(ACTIVATE_VENV)
-
-	pip install -e .[dev-dependencies]
-#	By default, psycopg2 is not installed
-#	but it should be for development
-	pip install -e src/database[postgres-binary]
-
-	rm -rf $(PACKAGE_INSTALL_DIR)
-	@echo '\nActivate your venv with `. $(VENV)/bin/activate`'
-
-cicd : venv filesystem-deps latest-pip
-	$(ACTIVATE_VENV)
-
-	pip install .[dev-dependencies]
-#	By default, psycopg2 is not installed
-#	but it should be for CI/CD
-	pip install src/database[postgres-binary]
-
-filesystem-deps : venv latest-pip
-	$(ACTIVATE_VENV)
-
 	pip install toml
+
+ $(call dep_to_venv_path,typing_extensions.py): $(VENV)
+	$(ACTIVATE_VENV)
+	pip install typing_extensions
+
+$(PACKAGE_PATHS) : $(VENV) $(SETUP_DEPENDENCIES)
+$(PYPROJECT_FILES) : $(VENV) $(SETUP_DEPENDENCIES)
+	$(ACTIVATE_VENV)
 
 	REWRITE_DEPENDENCIES=$(REWRITE_DEPENDENCIES) \
 	GITHUB_REF=$(GITHUB_REF) \
 	GITHUB_WORKSPACE=$(GITHUB_WORKSPACE) \
-	./.github/workflows/CICD-scripts/pyproject_dependency_rewrite.py
+	./.github/workflows/CICD-scripts/pyproject_dependency_rewrite.py -c $@
 
-latest-pip : venv
+
+$(VENV) :
+	test -d $(VENV) || env python$(PYTHON_VERSION) -m venv $(VENV)
+
 	$(ACTIVATE_VENV)
 
 	pip install -U pip
 
-venv :
-	test -d $(VENV) || env python$(PYTHON_VERSION) -m venv $(VENV)
 
-
-format-isort :
+format-isort : $(VENV) $(DEFAULT_TARGET)
 	$(ACTIVATE_VENV)
 
 	isort src 
 
-format-ruff :
+format-ruff : $(VENV) $(DEFAULT_TARGET)
 	$(ACTIVATE_VENV)
 
 	ruff format --preview --respect-gitignore
 
-format : format-isort format-ruff
+format : $(VENV) $(DEFAULT_TARGET) format-isort format-ruff
 
 
-test-isort :
+test-isort : $(VENV) $(DEFAULT_TARGET)
 	$(ACTIVATE_VENV)
 
 	isort --check-only src 
 
-test-ruff :
+test-ruff : $(VENV) $(DEFAULT_TARGET)
 	$(ACTIVATE_VENV)
 
 	ruff format --preview --respect-gitignore --check
 
-test-pyright :
+test-pyright : $(VENV) $(DEFAULT_TARGET)
 	$(ACTIVATE_VENV)
 
   ifeq "$(PYRIGHT_MODE)" "pip"
@@ -128,17 +195,18 @@ test-pyright :
   endif
   endif
 
-test-pytest :
+test-pytest : $(VENV) $(DEFAULT_TARGET)
 	$(ACTIVATE_VENV)
 
 	pytest $(PYTEST_FLAGS)
 	coverage html -d coverage
 
 test : CMD_PREFIX=@
-test : clean-test test-isort test-ruff test-pyright test-pytest
+test : $(VENV) $(DEFAULT_TARGET) clean-test test-isort test-ruff test-pyright test-pytest
 
 
-publish-all :
+# Publishing should use a real install, which `cicd` fulfills
+publish-all : $(VENV) cicd
 	$(ACTIVATE_VENV)
 
 	./publish_all.sh $(PYPI_REPO)
@@ -162,3 +230,15 @@ clean : clean-build clean-test
 	rm -rf $(VENV)
 
 	@echo '\nDeactivate your venv with `deactivate`'
+
+remake :
+	make clean
+	make
+
+reset-check:
+#   https://stackoverflow.com/a/47839479
+	@echo -n "This will make destructive changes! Considering stashing changes first.\n"
+	@( read -p "Are you sure? [y/N]: " response && case "$$response" in [yY]) true;; *) false;; esac )
+
+reset : reset-check clean
+	git checkout -- $(PYPROJECT_FILES)

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dev : venv filesystem-deps latest-pip
 
 	pip install -e .[dev-dependencies]
 #	By default, psycopg2 is not installed
-#   but it should be for development
+#	but it should be for development
 	pip install -e src/database[postgres-binary]
 
 #	rm -rf $(PACKAGE_INSTALL_DIR)
@@ -66,7 +66,7 @@ cicd : venv filesystem-deps latest-pip
 
 	pip install .[dev-dependencies]
 #	By default, psycopg2 is not installed
-#   but it should be for CI/CD
+#	but it should be for CI/CD
 	pip install src/database[postgres-binary]
 
 filesystem-deps : venv latest-pip
@@ -113,15 +113,15 @@ test-pyright :
 	$(ACTIVATE_VENV)
 
   ifeq "$(PYRIGHT_MODE)" "pip"
-		pyright
+	pyright
   else
   ifeq "$(PYRIGHT_MODE)" "npm"
-#		this isn't the real install path everywhere,
-#       but this is used for CI/CD
-		./node_modules/bin/pyright
+#	this isn't the real install path everywhere,
+#	but this is used for CI/CD
+	./node_modules/bin/pyright
   else
-		@echo "Invalid PYRIGHT_MODE '$(PYRIGHT_MODE)'"
-		@exit 1
+	@echo "Invalid PYRIGHT_MODE '$(PYRIGHT_MODE)'"
+	@exit 1
   endif
   endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,150 @@
+.ONESHELL:
+
+# Can be overridden to use a different directory name.
+ifeq ($(VENV),)
+  VENV := .venv
+endif
+
+# Can be overridden to use a different Python version.
+ifeq ($(PYTHON_VERSION),)
+  PYTHON_VERSION := 3.10
+endif
+
+# Can be overridden to pass flags to pytest, like `-k`.
+ifeq ($(PYTEST_FLAGS),)
+  PYTEST_FLAGS :=
+endif
+
+# Can be overridden to change what pyright command is run.
+# This is used to switch between the pip and npm commands.
+ifeq ($(PYRIGHT_MODE),)
+  PYRIGHT_MODE := pip
+endif
+
+# Can be overridden to change whether packages in the repo
+# will be installed from PyPI or the local filesystem.
+ifeq ($(REWRITE_DEPENDENCIES),)
+  REWRITE_DEPENDENCIES := true
+endif
+
+# Can be overridden.
+ifeq ($(GITHUB_REF),)
+  GITHUB_REF := 00000000-0000-0000-0000-000000000000
+endif
+
+# Can be overridden.
+ifeq ($(GITHUB_WORKSPACE),)
+  GITHUB_WORKSPACE := $(CURDIR)
+endif
+
+
+ACTIVATE_VENV := . $(VENV)/bin/activate
+
+PACKAGE_INSTALL_DIR := $(VENV)/lib/python*/site-packages/BL_Python
+
+# used to suppress outputs of targets (see `test` and `clean-test`)
+CMD_PREFIX=
+
+dev : venv filesystem-deps latest-pip
+	$(ACTIVATE_VENV)
+
+	pip install -e .[dev-dependencies]
+#	By default, psycopg2 is not installed
+#   but it should be for development
+	pip install -e src/database[postgres-binary]
+
+#	rm -rf $(PACKAGE_INSTALL_DIR)
+	@echo '\nActivate your venv with `. $(VENV)/bin/activate`'
+
+cicd : venv filesystem-deps latest-pip
+	$(ACTIVATE_VENV)
+
+	pip install .[dev-dependencies]
+#	By default, psycopg2 is not installed
+#   but it should be for CI/CD
+	pip install src/database[postgres-binary]
+
+filesystem-deps : venv latest-pip
+	$(ACTIVATE_VENV)
+
+	pip install toml
+
+	REWRITE_DEPENDENCIES=$(REWRITE_DEPENDENCIES) \
+	GITHUB_REF=$(GITHUB_REF) \
+	GITHUB_WORKSPACE=$(GITHUB_WORKSPACE) \
+	./.github/workflows/CICD-scripts/pyproject_dependency_rewrite.py
+
+latest-pip : venv
+	$(ACTIVATE_VENV)
+
+	pip install -U pip
+
+venv :
+	test -d $(VENV) || env python$(PYTHON_VERSION) -m venv $(VENV)
+
+format-isort :
+	$(ACTIVATE_VENV)
+
+	isort src 
+
+format-ruff :
+	$(ACTIVATE_VENV)
+
+	ruff format --preview --respect-gitignore
+
+format : format-isort format-ruff
+
+test-isort :
+	$(ACTIVATE_VENV)
+
+	isort --check-only src 
+
+test-ruff :
+	$(ACTIVATE_VENV)
+
+	ruff format --preview --respect-gitignore --check
+
+test-pyright :
+	$(ACTIVATE_VENV)
+
+  ifeq "$(PYRIGHT_MODE)" "pip"
+		pyright
+  else
+  ifeq "$(PYRIGHT_MODE)" "npm"
+#		this isn't the real install path everywhere,
+#       but this is used for CI/CD
+		./node_modules/bin/pyright
+  else
+		@echo "Invalid PYRIGHT_MODE '$(PYRIGHT_MODE)'"
+		@exit 1
+  endif
+  endif
+
+test-pytest :
+	$(ACTIVATE_VENV)
+
+	pytest $(PYTEST_FLAGS)
+	coverage html -d coverage
+
+
+test : CMD_PREFIX=@
+test : clean-test test-isort test-ruff test-pyright test-pytest
+
+clean-build :
+	find . -type d \( \
+		-name build \
+		-o -name __pycache__ \
+		-o -name \*.egg-info \
+		-o -name .pytest-cache \
+	\) -prune -exec rm -rf {} \;
+
+clean-test :
+	$(CMD_PREFIX)rm -rf cov.xml \
+		pytest.xml \
+		coverage \
+		.coverage 
+
+clean : clean-build clean-test
+	rm -rf $(VENV)
+
+	@echo '\nDeactivate your venv with `deactivate`'

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ PACKAGE_INSTALL_DIR := $(VENV)/lib/python*/site-packages/BL_Python
 # used to suppress outputs of targets (see `test` and `clean-test`)
 CMD_PREFIX=
 
+
 dev : venv filesystem-deps latest-pip
 	$(ACTIVATE_VENV)
 
@@ -87,6 +88,7 @@ latest-pip : venv
 venv :
 	test -d $(VENV) || env python$(PYTHON_VERSION) -m venv $(VENV)
 
+
 format-isort :
 	$(ACTIVATE_VENV)
 
@@ -98,6 +100,7 @@ format-ruff :
 	ruff format --preview --respect-gitignore
 
 format : format-isort format-ruff
+
 
 test-isort :
 	$(ACTIVATE_VENV)
@@ -131,14 +134,15 @@ test-pytest :
 	pytest $(PYTEST_FLAGS)
 	coverage html -d coverage
 
-
 test : CMD_PREFIX=@
 test : clean-test test-isort test-ruff test-pyright test-pytest
+
 
 publish-all :
 	$(ACTIVATE_VENV)
 
 	./publish_all.sh $(PYPI_REPO)
+
 
 clean-build :
 	find . -type d \( \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A collection of Python libraries for creating web applications, working with dat
 **🚩** `BL_Python` has a minimum Python version requirement of `>= 3.10`.
 
 * Create a BL_Python [web application](src/web/README.md)
-* Contribute to [BL_Python Development](https://github.com/uclahs-cds/BL_Python/wiki/BL_Python-Development)
+* Contribute to [BL_Python Development](https://github.com/uclahs-cds/BL_Python/wiki/BL_Python-Development). Run `make` to get started!
 
 
 # Available Libraries

--- a/install_all.sh
+++ b/install_all.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-# use $1 to pass in -e (or any other options)
-
-python -m pip install $1 .[dev-dependencies]

--- a/publish_all.sh
+++ b/publish_all.sh
@@ -6,13 +6,13 @@ spinwait_col=
 spinwait() {
     IFS=';'
     # inspiration https://unix.stackexchange.com/a/183121
-    read -sdR -p $'\E[6n' spinwait_row spinwait_col
+    read -sdRr -p $'\E[6n' spinwait_row spinwait_col
     spinwait_row="${spinwait_row#*[}"
 
     s=(\| / - \\)
     i=0
     while true; do
-        tput cup $((spinwait_row-1)) $spinwait_col 2> /dev/null
+        tput cup $((spinwait_row-1)) "$spinwait_col" 2> /dev/null
         echo -en "  ${s[i]}"; i=$(( (i + 1) % ${#s[@]}))
         sleep 0.2
     done &
@@ -21,7 +21,7 @@ spinwait() {
 spinwait-stop() {
     optional_msg=$1
     kill $spinwait_pid 2> /dev/null
-    tput cup $((spinwait_row-1)) $spinwait_col 2> /dev/null
+    tput cup $((spinwait_row-1)) "$spinwait_col" 2> /dev/null
     [ -n "$optional_msg" ] && echo -e "  $optional_msg" || echo -e "   "
 }
 
@@ -55,13 +55,13 @@ initialize() {
 
 build() {
     dir="$1"
-    pushd $dir 1> /dev/null
+    pushd "$dir" 1> /dev/null
     get-project-name
-    echo -n Building $project_name
+    echo -n "Building $project_name"
     spinwait
     rm -rf dist/
     python -m build 1> /dev/null
-    spinwait-stop done
+    spinwait-stop 'done'
     popd 1> /dev/null
 }
 
@@ -70,10 +70,10 @@ publish() {
     local dir="$1"
     local repository
     [ -n "$2" ] && repository="$2" || repository="testpypi"
-    pushd $dir 1> /dev/null
+    pushd "$dir" 1> /dev/null
     get-project-name
-    echo Publishing $project_name to $repository
-    python -m twine upload --repository $repository dist/*
+    echo "Publishing $project_name to $repository"
+    python -m twine upload --repository "$repository" dist/*
     popd 1> /dev/null
 }
 

--- a/publish_all.sh
+++ b/publish_all.sh
@@ -49,6 +49,10 @@ get-project-name() {
 
 trap 'spinwait-stop' ERR
 trap 'spinwait-stop; exit' SIGINT SIGTERM
+initialize() {
+    pip install -U build twine
+}
+
 build() {
     dir="$1"
     pushd $dir 1> /dev/null
@@ -84,6 +88,8 @@ declare -a packages=( \
     src/testing \
     src/web
 )
+
+initialize
 
 for package in ${packages[@]}; do
     build $package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,17 +79,13 @@ packages = [
 #
 [project.optional-dependencies]
 dev-dependencies = [
-    "pytest",
+    "pytest ~= 8.0",
     "pytest-mock",
     "mock",
-    "pytest-cov",
-
-    # code quality. allow minor version updates.
-    # this can possibly change behavior of quality checks,
-    # which allows us to catch new types of problems.
-    "pyright",
-    "isort",
-    "ruff == 0.2.2"
+    "pytest-cov ~= 4.1",
+    "pyright ~= 1.1",
+    "isort ~= 5.13",
+    "ruff ~= 0.3"
 ]
 
 [tool.pyright]


### PR DESCRIPTION
This Makefile is intended to make multi-machine development simpler. The mono-repo approach in BL_Python requires a few things that are now rolled up into a single `make dev` (or just `make`) command.

- Tests can also be executed with `make test`
- The CI/CD build can be executed with `make cicd`
- Automated formatting can be executed with `make format`
- Publishing to Test PyPI and PyPI can be done with `make publish-all`
- Clean up is done with `make clean`

The wiki will be updated to reflect this after merging this PR.