### PR TITLE
Pytest report extras

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -182,10 +182,7 @@ jobs:
         with:
           name: pytest-and-coverage-report
           path: |
-            pytest.xml
-            cov.xml
-            .coverage
-            coverage/
+            reports/pytest/
           retention-days: 1
           if-no-files-found: error
 

--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,14 @@ test-pyright : $(VENV) $(DEFAULT_TARGET)
 test-pytest : $(VENV) $(DEFAULT_TARGET)
 	$(ACTIVATE_VENV)
 
-	pytest $(PYTEST_FLAGS)
-	coverage html --data-file=$(REPORTS_DIR)/pytest/.coverage
+	pytest $(PYTEST_FLAGS) \
+		&& PYTEST_SUCCESS=0 \
+		|| PYTEST_SUCCESS=$$?
+
+	-coverage html --data-file=$(REPORTS_DIR)/pytest/.coverage
+	-junit2html $(REPORTS_DIR)/pytest/pytest.xml $(REPORTS_DIR)/pytest/pytest.html
+
+	exit $$PYTEST_SUCCESS
 
 .PHONY: test test-pytest test-pyright test-ruff test-isort
 _test : $(VENV) $(DEFAULT_TARGET) test-isort test-ruff test-pyright test-pytest

--- a/Makefile
+++ b/Makefile
@@ -208,13 +208,13 @@ test-pytest : $(VENV) $(DEFAULT_TARGET)
 	$(ACTIVATE_VENV)
 
 	pytest $(PYTEST_FLAGS) \
-		&& PYTEST_SUCCESS=0 \
-		|| PYTEST_SUCCESS=$$?
+		&& PYTEST_EXIT_CODE=0 \
+		|| PYTEST_EXIT_CODE=$$?
 
 	-coverage html --data-file=$(REPORTS_DIR)/pytest/.coverage
 	-junit2html $(REPORTS_DIR)/pytest/pytest.xml $(REPORTS_DIR)/pytest/pytest.html
 
-	exit $$PYTEST_SUCCESS
+	exit $$PYTEST_EXIT_CODE
 
 .PHONY: test test-pytest test-pyright test-ruff test-isort
 _test : $(VENV) $(DEFAULT_TARGET) test-isort test-ruff test-pyright test-pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ dev-dependencies = [
     "mock",
     "pytest-cov ~= 4.1",
     "coverage ~= 7.4",
+    "junit2html ~= 30.1",
     "pyright ~= 1.1",
     "isort ~= 5.13",
     "ruff ~= 0.3"

--- a/src/database/BL_Python/database/config.py
+++ b/src/database/BL_Python/database/config.py
@@ -1,4 +1,5 @@
-from BL_Python.programming.collections.dict import AnyDict
+from typing import Any
+
 from BL_Python.programming.config import AbstractConfig
 from pydantic import BaseModel
 from pydantic.config import ConfigDict
@@ -26,7 +27,7 @@ class SQLiteDatabaseConnectArgsConfig(DatabaseConnectArgsConfig):
 
 
 class DatabaseConfig(BaseModel, AbstractConfig):
-    def __init__(self, **data: AnyDict):
+    def __init__(self, **data: Any):
         super().__init__(**data)
 
         model_data = self.connect_args.model_dump() if self.connect_args else {}

--- a/src/database/BL_Python/database/config.py
+++ b/src/database/BL_Python/database/config.py
@@ -39,7 +39,7 @@ class DatabaseConfig(BaseModel, AbstractConfig):
     sqlalchemy_echo: bool = False
     # the static field allows Pydantic to store
     # values from a dictionary
-    connect_args: DatabaseConnectArgsConfig | None
+    connect_args: DatabaseConnectArgsConfig | None = None
 
 
 class Config(BaseModel, AbstractConfig):

--- a/src/database/test/unit/migrations/alembic/test_env.py
+++ b/src/database/test/unit/migrations/alembic/test_env.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import ANY
 
 import pytest
 from BL_Python.database.migrations.alembic.env import run_migrations


### PR DESCRIPTION
- Generate an HTML report from the JUnit pytest.xml files
- Fix an error with trying to remove files that don't exist - the files now exist under `$(REPORTS_DIR)`
- Make the `test-pyright` target ignore errors from `coverage` and `junit2html` so that both are guaranteed to run, and store `pytest`'s exit code to be returned at the end of the target to accurately report success/failure