### PR TITLE
Add SAST scanner

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -225,7 +225,6 @@ jobs:
           echo Running bandit
 
           VENV=.github-venv \
-          PYTEST_FLAGS="-k 'not acceptance'" \
           DEFAULT_TARGET=cicd \
             make test-bandit
 

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -230,7 +230,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
-          name: pytest-and-coverage-report
+          name: bandit-sast-report
           path: |
             bandit.sarif
           retention-days: 1

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -229,7 +229,7 @@ jobs:
           DEFAULT_TARGET=cicd \
             make test-bandit
 
-      - name: Output bandit report
+      - name: Output bandit report artifact
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
@@ -238,6 +238,11 @@ jobs:
             bandit.sarif
           retention-days: 1
           if-no-files-found: error
+
+      - name: Upload bandit report to CodeQL
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: bandit.sarif
 
   Style:
     name: Style and formatting

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -140,6 +140,7 @@ jobs:
 
           VENV=.github-venv \
           PYRIGHT_MODE=npm \
+          DEFAULT_TARGET=cicd \
             make test-pyright
 
   Pytest:
@@ -174,6 +175,7 @@ jobs:
 
           VENV=.github-venv \
           PYTEST_FLAGS="-k 'not acceptance'" \
+          DEFAULT_TARGET=cicd \
             make test-pytest
 
       - name: Output pytest report
@@ -224,6 +226,7 @@ jobs:
 
           VENV=.github-venv \
           PYTEST_FLAGS="-k 'not acceptance'" \
+          DEFAULT_TARGET=cicd \
             make test-bandit
 
       - name: Output bandit report
@@ -265,11 +268,13 @@ jobs:
       - name: Check code style
         run: |
           VENV=.github-venv \
+          DEFAULT_TARGET=cicd \
             make test-ruff
 
       - name: Check import order
         run: |
           VENV=.github-venv \
+          DEFAULT_TARGET=cicd \
             make test-isort
 
   Final-status-check:

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -205,7 +205,13 @@ jobs:
 
           VENV=.github-venv \
           DEFAULT_TARGET=cicd \
-            make test-bandit
+            make test-bandit || BANDIT_EXIT_CODE=$?
+
+          echo "Bandit exit code: $BANDIT_EXIT_CODE"
+
+          if [ $BANDIT_EXIT_CODE -ne 0 ]; then
+            echo "::warning title=Bandit::Bandit exit code: $BANDIT_EXIT_CODE"
+          fi
 
       - name: Output bandit report artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -189,6 +189,53 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  Bandit:
+    name: SAST scanning
+    runs-on: ubuntu-latest
+    needs:
+      - Checkout
+
+    env:
+      PYTHON_VERSION: "3.10"
+
+    if: ${{( success() && !cancelled() ) }}
+
+    # FIXME Ignore errors while testing Bandit
+    continue-on-error: true
+
+    steps:
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        id: install_python
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/cache/restore@v4
+        name: Restore run cache
+        id: restore-run-cache
+        with:
+          key: ${{ needs.Checkout.outputs.cache-key-run }}
+          path: ${{ github.workspace }}
+          fail-on-cache-miss: true
+
+      - name: Run bandit scan and generate reports
+        run: |
+          echo Running bandit
+
+          VENV=.github-venv \
+          PYTEST_FLAGS="-k 'not acceptance'" \
+            make test-bandit
+
+      - name: Output bandit report
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: pytest-and-coverage-report
+          path: |
+            bandit.sarif
+          retention-days: 1
+          if-no-files-found: error
+
   Style:
     name: Style and formatting
     runs-on: ubuntu-latest
@@ -232,6 +279,7 @@ jobs:
       - Checkout
       - Pyright
       - Pytest
+      - Bandit
       - Style
     # this job should run regardless of success, failure, or skips,
     # but not if the workflow is cancelled. `always()` ignores cancelled,

--- a/Makefile
+++ b/Makefile
@@ -197,14 +197,12 @@ test-pyright : $(VENV) $(BUILD_TARGET)
 test-bandit : $(VENV) $(BUILD_TARGET)
 	$(ACTIVATE_VENV)
 
-	bandit -c pyproject.toml \
-		--format sarif \
-		--output $(BANDIT_REPORT) \
-		-r . || BANDIT_EXIT_CODE=$$?
-
 #	don't exit with an error
 #	while testing bandit.
-	@echo "Bandit exit code: $$BANDIT_EXIT_CODE"
+	-bandit -c pyproject.toml \
+		--format sarif \
+		--output $(BANDIT_REPORT) \
+		-r .
 
 test-pytest : $(VENV) $(BUILD_TARGET)
 	$(ACTIVATE_VENV)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ dev-dependencies = [
     "pytest-cov ~= 4.1",
     "pyright ~= 1.1",
     "isort ~= 5.13",
-    "ruff ~= 0.3"
+    "ruff ~= 0.3",
+    "bandit[sarif,toml] ~= 1.7"
 ]
 
 [tool.pyright]
@@ -209,6 +210,21 @@ omit = [
     "*/__pycache__/*"
 ]
 branch = true
+
+[tool.bandit]
+exclude_dirs = [
+    "./build/*",
+    "./.github-venv/*",
+    "./.pytest_cache/*",
+    "./typings/*",
+    "./node_modules/*",
+    "./__pycache__/*",
+    "./.github/*",
+    "./.venv/*",
+    "./.git/*",
+    "./test/*/test*.py",
+    "./src/*/test/*/test*.py"
+]
 
 [tool.ruff]
 include = [


### PR DESCRIPTION
This PR adds Bandit as a SAST scanning tool. The Makefile and CI/CD reflect its addition, and are able to generate reports. The report results are visible [here](https://github.com/uclahs-cds/BL_Python/security/code-scanning?query=pr%3A56+is%3Aopenhttps://github.com/uclahs-cds/BL_Python/security/code-scanning?query=pr%3A56+is%3Aopen).

This PR also contains several changes in target chains for the Makefile as well as how Python commands are called because something crazy and inexplicable happened in GitHub Actions. I think I have finally fixed it.

A successful SAST scan is not required while this tool is tested.