### PR TITLE
Fix type annotation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 # `BL_Python.web` [0.2.1] - 2024-05-16
 - [BL_Python.web v0.2.1](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.web-v0.2.1/src/web/CHANGELOG.md#021---2024-05-16)
 
-# `BL_Python.platform` [0.2.1] - 2024-05-16
-- [BL_Python.platform v0.2.1](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.platform-v0.2.1/src/platform/CHANGELOG.md#021---2024-05-16)
+# `BL_Python.platform` [0.2.2] - 2024-05-16
+- [BL_Python.platform v0.2.2](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.platform-v0.2.2/src/platform/CHANGELOG.md#021---2024-05-16)
 
 # [0.2.0] - 2024-05-14
 ### Added

--- a/src/platform/BL_Python/platform/__init__.py
+++ b/src/platform/BL_Python/platform/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "0.2.1"
+__version__: str = "0.2.2"

--- a/src/platform/BL_Python/platform/identity/user_loader.py
+++ b/src/platform/BL_Python/platform/identity/user_loader.py
@@ -104,7 +104,7 @@ class UserLoader(Generic[TUserMixin]):
             # relationships and referencing the relevant columns.
             user_table_property_mapper = cast(Mapper, class_mapper(self._user_table))
             user_table_properties = cast(
-                list[RelationshipProperty[DbRole] | ColumnProperty],
+                "list[RelationshipProperty[DbRole] | ColumnProperty]",
                 user_table_property_mapper.iterate_properties,  # pyright: ignore[reportUnknownMemberType]
             )
             # Only extract the secondary join table (user_role).

--- a/src/platform/CHANGELOG.md
+++ b/src/platform/CHANGELOG.md
@@ -10,7 +10,7 @@ Review the `BL_Python` [CHANGELOG.md](https://github.com/uclahs-cds/BL_Python/bl
 
 ---
 
-## [0.2.1] - 2024-05-16
+## [0.2.2] - 2024-05-16
 ### Changed
 - Ignore sentinel files created by `make`.
 


### PR DESCRIPTION
Fix this error:

```
Traceback (most recent call last):
  File ".venv/lib/python3.10/site-packages/BL_Python/platform/identity/user_loader.py", line 107, in user_loader
    list[RelationshipProperty[DbRole] | ColumnProperty],
TypeError: 'type' object is not subscriptable
```