### PR TITLE
Fix problem with application crashing when query string is stored as bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
-# `BL_Python.web` [0.2.1] - 2024-05-16
-- [BL_Python.web v0.2.1](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.web-v0.2.1/src/web/CHANGELOG.md#021---2024-05-16)
+# `BL_Python.web` [0.2.2] - 2024-05-16
+- [BL_Python.web v0.2.2](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.web-v0.2.2/src/web/CHANGELOG.md#022---2024-05-16)
 
 # `BL_Python.platform` [0.2.2] - 2024-05-16
-- [BL_Python.platform v0.2.2](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.platform-v0.2.2/src/platform/CHANGELOG.md#021---2024-05-16)
+- [BL_Python.platform v0.2.2](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.platform-v0.2.2/src/platform/CHANGELOG.md#022---2024-05-16)
+
+# `BL_Python.all` [0.2.3] - 2024-05-16
+- Contains all libraries up to v0.2.1, and `BL_Python.platform` v0.2.2 and `BL_Python.web` v0.2.2
 
 # [0.2.0] - 2024-05-14
 ### Added

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "0.2.2"
+__version__: str = "0.2.3"

--- a/src/web/BL_Python/web/__init__.py
+++ b/src/web/BL_Python/web/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "0.2.1"
+__version__: str = "0.2.2"

--- a/src/web/BL_Python/web/middleware/openapi/__init__.py
+++ b/src/web/BL_Python/web/middleware/openapi/__init__.py
@@ -530,6 +530,12 @@ class FlaskContextMiddleware:
                         }),
                     )
 
+                    # Some values, like the query string, are stored as bytes.
+                    # Decode as a UTF-8 str so encoding later doesn't fail.
+                    for key, value in request_environ.items():
+                        if isinstance(value, bytes):
+                            request_environ[key] = value.decode("utf-8")
+
                     request_ctx = exit_stack.enter_context(
                         app.request_context(request_environ)
                     )

--- a/src/web/CHANGELOG.md
+++ b/src/web/CHANGELOG.md
@@ -10,9 +10,10 @@ Review the `BL_Python` [CHANGELOG.md](https://github.com/uclahs-cds/BL_Python/bl
 
 ---
 
-## [0.2.1] - 2024-05-16
+## [0.2.2] - 2024-05-16
 ### Changed
 - Ignore sentinel files created by `make`.
 
 ### Fixed
 - Update type annotation for variable causing new failure in Pyright.
+- Resolved crash when query string is stored as a byte array.


### PR DESCRIPTION
In the Connexion context middleware, if the query string is stored as a byte array, the application will crash when it attempts to re-encode the value. To avoid that, decode the data as a UTF-8 string.