### PR TITLE
Alter how CORS is handled in BL_Python.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
-## [Unreleased]
+# `BL_Python.all` [0.2.4] - 2024-05-17
 
-# `BL_Python.web` [0.2.2] - 2024-05-16
-- [BL_Python.web v0.2.2](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.web-v0.2.2/src/web/CHANGELOG.md#022---2024-05-16)
-
-# `BL_Python.platform` [0.2.2] - 2024-05-16
-- [BL_Python.platform v0.2.2](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.platform-v0.2.2/src/platform/CHANGELOG.md#022---2024-05-16)
+## `BL_Python.web` [0.2.3] - 2024-05-17
+- [BL_Python.web v0.2.3](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.web-v0.2.3/src/web/CHANGELOG.md#023---2024-05-17)
 
 # `BL_Python.all` [0.2.3] - 2024-05-16
 - Contains all libraries up to v0.2.1, and `BL_Python.platform` v0.2.2 and `BL_Python.web` v0.2.2
+
+## `BL_Python.web` [0.2.2] - 2024-05-16
+- [BL_Python.web v0.2.2](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.web-v0.2.2/src/web/CHANGELOG.md#022---2024-05-16)
+
+## `BL_Python.platform` [0.2.2] - 2024-05-16
+- [BL_Python.platform v0.2.2](https://github.com/uclahs-cds/BL_Python/blob/BL_Python.platform-v0.2.2/src/platform/CHANGELOG.md#022---2024-05-16)
 
 # [0.2.0] - 2024-05-14
 ### Added

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "0.2.3"
+__version__: str = "0.2.4"

--- a/src/web/BL_Python/web/__init__.py
+++ b/src/web/BL_Python/web/__init__.py
@@ -1,1 +1,1 @@
-__version__: str = "0.2.2"
+__version__: str = "0.2.3"

--- a/src/web/BL_Python/web/config.py
+++ b/src/web/BL_Python/web/config.py
@@ -12,8 +12,8 @@ class LoggingConfig(BaseModel):
 
 
 class WebSecurityCorsConfig(BaseModel):
-    origin: str | None = None
-    allow_credentials: bool = True
+    origins: list[str] | None = None
+    allow_credentials: bool = False
     allow_methods: list[
         Literal[
             "GET",
@@ -27,6 +27,7 @@ class WebSecurityCorsConfig(BaseModel):
             "TRACE",
         ]
     ] = field(default_factory=lambda: ["GET", "POST", "OPTIONS"])
+    allow_headers: list[str | Literal["*"]] = field(default_factory=lambda: ["*"])
 
 
 class WebSecurityConfig(BaseModel):

--- a/src/web/BL_Python/web/middleware/dependency_injection.py
+++ b/src/web/BL_Python/web/middleware/dependency_injection.py
@@ -87,7 +87,9 @@ def configure_dependencies(
                 module, "register_middleware", None
             )
             if register_callback is not None and callable(register_callback):
-                register_callback(app)
+                flask_injector.injector.call_with_injection(
+                    register_callback, kwargs={"app": app}
+                )
 
         # this binds all BL_Python middlewares with Injector
         _configure_openapi_middleware_dependencies(app, flask_injector)

--- a/src/web/BL_Python/web/middleware/flask/__init__.py
+++ b/src/web/BL_Python/web/middleware/flask/__init__.py
@@ -161,17 +161,29 @@ def _ordered_api_response_handers(response: Response, config: Config, log: Logge
 def _wrap_all_api_responses(response: Response, config: Config, log: Logger):
     correlation_id = _get_correlation_id(log)
 
-    cors_domain: str | None = None
-    if config.web.security.cors.origin:
-        cors_domain = config.web.security.cors.origin
+    cors_domains: list[str] | None = None
+    if config.web.security.cors.origins:
+        cors_domains = config.web.security.cors.origins
     else:
         if not response.headers.get(CORS_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER):
-            cors_domain = request.headers.get(ORIGIN_HEADER)
-            if not cors_domain:
-                cors_domain = request.headers.get(HOST_HEADER)
+            cors_domains = (
+                (header_value := request.headers.get(ORIGIN_HEADER))
+                and [header_value]
+                or None
+            )
+            if not cors_domains:
+                cors_domains = (
+                    (header_value := request.headers.get(HOST_HEADER))
+                    and [header_value]
+                    or None
+                )
 
-    if cors_domain:
-        response.headers[CORS_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER] = cors_domain
+    if cors_domains:
+        # although the config allows multiple, the header may only contain one.
+        # either only one will have been set, or we take the first from the config.
+        # this may not be valid in all cases, and so the ASGI CORSMiddleware sould
+        # be used instead
+        response.headers[CORS_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER] = cors_domains[0]
 
     response.headers[CORS_ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER] = str(
         config.web.security.cors.allow_credentials

--- a/src/web/BL_Python/web/middleware/openapi/__init__.py
+++ b/src/web/BL_Python/web/middleware/openapi/__init__.py
@@ -27,12 +27,7 @@ from ...config import Config
 from ..consts import (
     CONTENT_SECURITY_POLICY_HEADER,
     CORRELATION_ID_HEADER,
-    CORS_ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER,
-    CORS_ACCESS_CONTROL_ALLOW_METHODS_HEADER,
-    CORS_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER,
-    HOST_HEADER,
     INCOMING_REQUEST_MESSAGE,
-    ORIGIN_HEADER,
     OUTGOING_RESPONSE_MESSAGE,
     REQUEST_COOKIE_HEADER,
     RESPONSE_COOKIE_HEADER,
@@ -233,39 +228,6 @@ def _wrap_all_api_responses(
 ):
     correlation_id = _get_correlation_id(request, response, log)
     response_headers = _headers_as_dict(response)
-
-    cors_domains: list[str] | None = None
-    if config.web.security.cors.origins:
-        cors_domains = config.web.security.cors.origins
-    else:
-        if not response_headers.get(CORS_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER):
-            request_headers = _headers_as_dict(request)
-            cors_domains = (
-                (header_value := request_headers.get(ORIGIN_HEADER))
-                and [header_value]
-                or None
-            )
-            if not cors_domains:
-                cors_domains = (
-                    (header_value := request_headers.get(HOST_HEADER))
-                    and [header_value]
-                    or None
-                )
-
-    if cors_domains:
-        # although the config allows multiple, the header may only contain one.
-        # either only one will have been set, or we take the first from the config.
-        # this may not be valid in all cases, and so the ASGI CORSMiddleware sould
-        # be used instead
-        response_headers[CORS_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER] = cors_domains[0]
-
-    response_headers[CORS_ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER] = str(
-        config.web.security.cors.allow_credentials
-    )
-
-    response_headers[CORS_ACCESS_CONTROL_ALLOW_METHODS_HEADER] = ",".join(
-        config.web.security.cors.allow_methods
-    )
 
     response_headers[CORRELATION_ID_HEADER] = correlation_id
 

--- a/src/web/BL_Python/web/middleware/openapi/cors.py
+++ b/src/web/BL_Python/web/middleware/openapi/cors.py
@@ -1,0 +1,20 @@
+from BL_Python.web.config import Config
+from connexion import FlaskApp
+from connexion.middleware import MiddlewarePosition
+from injector import Module, inject
+from starlette.middleware.cors import CORSMiddleware
+
+
+class CORSMiddlewareModule(Module):
+    @inject
+    def register_middleware(self, app: FlaskApp, config: Config):
+        cors_config = config.web.security.cors
+
+        app.add_middleware(
+            CORSMiddleware,
+            position=MiddlewarePosition.BEFORE_EXCEPTION,
+            allow_origins=cors_config.origins,
+            allow_credentials=cors_config.allow_credentials,
+            allow_methods=cors_config.allow_methods,
+            allow_headers=cors_config.allow_headers,
+        )

--- a/src/web/BL_Python/web/scaffolding/templates/basic/{{application.module_name}}/config.toml.j2
+++ b/src/web/BL_Python/web/scaffolding/templates/basic/{{application.module_name}}/config.toml.j2
@@ -27,7 +27,7 @@ log_level = 'INFO'
 format = 'JSON'
 
 [web.security.cors]
-origin = 'http://localhost:5000'
+origins = ['http://localhost:5000']
 allow_credentials = true
 allow_methods = ['GET', 'POST', 'PATCH', 'OPTIONS']
 

--- a/src/web/BL_Python/web/scaffolding/templates/openapi/{{application.module_name}}/config.toml.j2
+++ b/src/web/BL_Python/web/scaffolding/templates/openapi/{{application.module_name}}/config.toml.j2
@@ -34,7 +34,7 @@ log_level = 'INFO'
 format = 'plaintext'
 
 [web.security.cors]
-origin = 'http://localhost:5000'
+origins = ['http://localhost:5000']
 allow_credentials = true
 allow_methods = ['GET', 'POST', 'PATCH', 'OPTIONS']
 

--- a/src/web/CHANGELOG.md
+++ b/src/web/CHANGELOG.md
@@ -9,6 +9,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Review the `BL_Python` [CHANGELOG.md](https://github.com/uclahs-cds/BL_Python/blob/main/CHANGELOG.md) for full monorepo notes.
 
 ---
+## Unreleased
+
+## [0.2.3] - 2024-05-17
+### Changed
+- Flask and OpenAPI apps require configuration of CORS origins as an array
+  - Flask apps still only supports a single origin
+- OpenAPI apps use `CORSMiddleware` in favor of the custom CORS handlers
+
+### Added
+- Custom middleware modules can now use Injector to get interfaces that have been previously registered
 
 ## [0.2.2] - 2024-05-16
 ### Changed

--- a/src/web/test/unit/middleware/test_api_response_handlers.py
+++ b/src/web/test/unit/middleware/test_api_response_handlers.py
@@ -49,7 +49,7 @@ class TestApiResponseHandlers(CreateFlaskApp):
     @pytest.mark.parametrize(
         "header,value,config_attribute_name",
         [
-            (CORS_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "example.com", "origin"),
+            (CORS_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, ["example.com"], "origins"),
             (
                 CORS_ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER,
                 "False",


### PR DESCRIPTION
In this PR:

- Adjust CORS configuration to support multiple origins

For Flask apps:

- Handle the change in config to support using the first domain listed in the CORS config as the Origin URL

For OpenAPI apps:

- Use `CORSMiddleware` instead of the custom handlers
- Call custom middlewares with Injector to allow these middlewares to use registered interfaces through DI