### PR TITLE
Added classes to deal with ASGI library limitations.

### DIFF
--- a/src/web/BL_Python/web/host/__init__.py
+++ b/src/web/BL_Python/web/host/__init__.py
@@ -1,0 +1,13 @@
+from BL_Python.programming.collections.dict import merge
+from uvicorn.workers import UvicornWorker
+
+
+class LifespanUvicornWorker(UvicornWorker):
+    CONFIG_KWARGS = merge(UvicornWorker.CONFIG_KWARGS, {"lifespan": "on"})
+
+
+class ProxiedUvicornWorker(LifespanUvicornWorker):
+    CONFIG_KWARGS = merge(
+        UvicornWorker.CONFIG_KWARGS,
+        {"proxy_headers": True, "forwarded_allow_ips": "*"},
+    )

--- a/src/web/BL_Python/web/middleware/openapi/__init__.py
+++ b/src/web/BL_Python/web/middleware/openapi/__init__.py
@@ -1,5 +1,6 @@
 import re
 import uuid
+from collections.abc import Iterable
 from contextlib import ExitStack
 from contextvars import Token
 from logging import Logger
@@ -493,7 +494,9 @@ class FlaskContextMiddleware:
                             "REMOTE_ADDR": ":".join([
                                 str(value) for value in scope["client"]
                             ])
-                            or f"{context.request._starlette_request.client.host}:{context.request._starlette_request.client.port}",
+                            if (client := scope.get("client"))
+                            and isinstance(client, Iterable)
+                            else f"{context.request._starlette_request.client.host}:{context.request._starlette_request.client.port}",
                         },
                         dict({
                             (

--- a/src/web/CHANGELOG.md
+++ b/src/web/CHANGELOG.md
@@ -14,6 +14,10 @@ Review the `BL_Python` [CHANGELOG.md](https://github.com/uclahs-cds/BL_Python/bl
 ### Added
 - ASGI worker classes to support ASGI lifetime and proxy options when running ASGI applications #68
 
+### Fixed
+- Correctly resolve server hostname and remote address when running application with gunicorn #68
+- Log correct username #68
+
 ## [0.2.3] - 2024-05-17
 ### Changed
 - Flask and OpenAPI apps require configuration of CORS origins as an array

--- a/src/web/CHANGELOG.md
+++ b/src/web/CHANGELOG.md
@@ -11,6 +11,9 @@ Review the `BL_Python` [CHANGELOG.md](https://github.com/uclahs-cds/BL_Python/bl
 ---
 ## Unreleased
 
+### Added
+- ASGI worker classes to support ASGI lifetime and proxy options when running ASGI applications #68
+
 ## [0.2.3] - 2024-05-17
 ### Changed
 - Flask and OpenAPI apps require configuration of CORS origins as an array

--- a/src/web/pyproject.toml
+++ b/src/web/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "flask-login",
     "connexion == 3.0.6",
     "connexion[uvicorn]",
+    "uvicorn-worker",
     "swagger_ui_bundle",
     "python-dotenv",
     "json-logging",


### PR DESCRIPTION
The recommended way of hosting an asgi application (using gunicorn with an uvicorn worker) causes this error https://github.com/encode/starlette/discussions/2408 in some middleware.

The recommended way to run the asgi application does not contain key command-line arguments needed to make some ASGI applications work, notably when the application is behind nginx.

The undocumented way to gain the needed cli arguments is to extend the existing UvicornWorker classes. This PR resolves that. https://github.com/encode/uvicorn/issues/343

This PR also resolves a crash when the HTTP request `client` variable is `None`.