### PR TITLE
For Pyright version to 1.1.366 to fix CICD until new Pyright version is released.

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -78,7 +78,8 @@ jobs:
             make cicd
 
           echo 'prefix=${{ github.workspace }}/node_modules' >> ~/.npmrc
-          npm install -g pyright@`pyright --version | awk '{print $2}'`
+          . .github-venv/bin/activate && \
+          npm install -g "pyright@`pyright --version | awk '/^pyright [0-9]/{print $2}'`"
 
       - name: Save run cache
         uses: actions/cache/save@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,9 @@ dev-dependencies = [
     "pytest-cov ~= 4.1",
     "coverage ~= 7.4",
     "junit2html ~= 30.1",
-    "pyright ~= 1.1",
+    # Pyright >= 1.1.367 breaks the build.
+    # Waiting for new pyright release to fix it. https://github.com/uclahs-cds/BL_Python/issues/79
+    "pyright == 1.1.366",
     "isort ~= 5.13",
     "ruff ~= 0.3",
     "bandit[sarif,toml] ~= 1.7"


### PR DESCRIPTION
While we wait for a new Pyright version, forcing Pyright to version 1.1.366 fixes the build. This will allow us to merge the Dependabot PRs that are currently blocked.

Related #79

