### PR TITLE
Correctly remove sentinel file in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ clean-test :
 clean : clean-build clean-test
 	rm -rf $(VENV)
 	rm -rf $(MAKE_ARTIFACT_DIRECTORY)
+	rm -f  $(PYPROJECT_FILES_SENTINEL)
 	@echo '\nDeactivate your venv with `deactivate`'
 
 .PHONY: remake


### PR DESCRIPTION
If `$(PYPROJECT_FILES_SENTINEL)` exists, `make` will not correctly re-make BL_Python. This change adds it to the Makefile `clean` target, which it should have already contained.