### PR TITLE
Resolve problem with SQLAlchemy sessions staying open

### DIFF
--- a/src/database/test/unit/schema/test_dialect.py
+++ b/src/database/test/unit/schema/test_dialect.py
@@ -16,6 +16,7 @@ def get_test_table(schema_name: str | None = "foo_schema"):
     if schema_name is None:
 
         class _Base: ...  # pyright: ignore[reportRedeclaration]
+
     else:
 
         class _Base:


### PR DESCRIPTION
This may be the cause of errors in CAP when SQLAlchemy tries to user a connection in the pool that has been invalidated due to timeout.

The issue here is that the session created is not closed, and the transaction is not rolled back or committed.