### PR TITLE
Add Tox to manage dynamic options with `pytest`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.rd[as]
 
 # Python
+.tox
 .coverage
 coverage
 cov.xml

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ PYPI_REPO ?= testpypi
 REPORTS_DIR ?= reports
 BANDIT_REPORT := bandit.sarif
 PYTEST_REPORT := pytest
+PYTEST_TARGET ?= .
+TOX_DIR := .tox
 
 
 # Can be overridden. This is used to change the prereqs
@@ -195,7 +197,7 @@ test-bandit : $(VENV) $(BUILD_TARGET)
 
 test-pytest : $(VENV) $(BUILD_TARGET)
 	-$(ACTIVATE_VENV) && \
-	pytest $(PYTEST_FLAGS) && PYTEST_EXIT_CODE=0 || PYTEST_EXIT_CODE=$$?; \
+	PYTEST_TARGET=$(PYTEST_TARGET) tox && PYTEST_EXIT_CODE=0 || PYTEST_EXIT_CODE=$$?; \
 	coverage html --data-file=$(REPORTS_DIR)/$(PYTEST_REPORT)/.coverage; \
 	junit2html $(REPORTS_DIR)/$(PYTEST_REPORT)/pytest.xml $(REPORTS_DIR)/$(PYTEST_REPORT)/pytest.html; \
 	exit $$PYTEST_EXIT_CODE
@@ -230,6 +232,7 @@ clean-build :
 
 clean-test :
 	$(CMD_PREFIX)rm -rf \
+		$(TOX_DIR) \
 		$(REPORTS_DIR)/$(PYTEST_REPORT) \
 		$(REPORTS_DIR)/$(BANDIT_REPORT)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ legacy_tox_ini = """
     [testenv]
     # these options make Tox use the existing .venv dir created by venv
     envdir = {env:VENV:.venv}
-    usedevelop = true
     recreate = false
     skip_install = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,8 +210,6 @@ legacy_tox_ini = """
         # for a subset of tests in the monorepo rather
         # than for all tests in the repo.
         PYTEST_ADDOPTS = --cov={env:PYTEST_TARGET:.}
-        # additional pytest flags - defaults to no flags
-        PYTEST_FLAGS = {env:PYTEST_FLAGS:}
     commands =
         # use `.` add the default --cov option if it's not specified
         pytest {env:PYTEST_FLAGS} {env:PYTEST_ADDOPTS:--cov=.} {env:PYTEST_TARGET}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,14 +82,13 @@ packages = [
 #
 [project.optional-dependencies]
 dev-dependencies = [
+    "tox ~= 4.18",
     "pytest ~= 8.0",
     "pytest-mock",
     "mock",
     "pytest-cov >= 4.1,< 5.0",
     "coverage ~= 7.4",
     "junit2html >= 30.1,< 32.0",
-    # Pyright >= 1.1.367 breaks the build.
-    # Waiting for new pyright release to fix it. https://github.com/uclahs-cds/BL_Python/issues/79
     "pyright == 1.1.379",
     "isort ~= 5.13",
     "ruff ~= 0.3",
@@ -183,7 +182,6 @@ addopts = [
     # https://github.com/microsoft/vscode-python/issues/21255
     # and
     # https://github.com/microsoft/vscode-python/issues/21845
-    "--cov=.",
     "--junitxml=reports/pytest/pytest.xml",
     "-o=junit_family=xunit2",
     "--cov-report=xml:reports/pytest/cov.xml",
@@ -193,6 +191,32 @@ addopts = [
 python_files = "test_*.py"
 
 norecursedirs = "__pycache__ build .pytest_cache *.egg-info .venv .github-venv"
+
+[tool.tox]
+legacy_tox_ini = """
+    [tox]
+    envlist = py310
+
+    [testenv]
+    # these options make Tox use the existing .venv dir created by venv
+    envdir = {env:VENV:.venv}
+    usedevelop = true
+    recreate = false
+    skip_install = true
+
+    setenv =
+        # configure --cov here because we can't use
+        # envvars in pyproject.toml, and we want this
+        # to be configurable in order to test coverage
+        # for a subset of tests in the monorepo rather
+        # than for all tests in the repo.
+        PYTEST_ADDOPTS = --cov={env:PYTEST_TARGET:.}
+        # additional pytest flags - defaults to no flags
+        PYTEST_FLAGS = {env:PYTEST_FLAGS:}
+    commands =
+        # use `.` add the default --cov option if it's not specified
+        pytest {env:PYTEST_FLAGS} {env:PYTEST_ADDOPTS:--cov=.} {env:PYTEST_TARGET}
+"""
 
 [tool.coverage.report]
 include_namespace_packages = true


### PR DESCRIPTION
These changes support incoming updates to generated coverage reports for each separate library within the monorepo. Currently we can only get one big coverage report for the whole repo, which provides a "false" view of how well covered each individual library is. Unfortunately, the way `--cov` needs to be changed (and to continue supporting ease of use for developers), means some tool needs to be introduced to support the dynamism. Tox happens to fit this use case.

