### PR TITLE
Revert "Bump pyright from 1.1.380 to 1.1.381"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dev-dependencies = [
     "pytest-cov >= 4.1,< 5.0",
     "coverage ~= 7.4",
     "junit2html >= 30.1,< 32.0",
-    "pyright == 1.1.381",
+    "pyright == 1.1.380",
     "isort ~= 5.13",
     "ruff ~= 0.3",
     "bandit[sarif,toml] ~= 1.7"


### PR DESCRIPTION
Reverts uclahs-cds/BL_Python#108

Pyright == 1.1.381 appears to be broken on my machine. To save my sanity, I'm rolling this back for now.